### PR TITLE
implementando cruzamento de nome e setor TODO 10

### DIFF
--- a/unitins.py
+++ b/unitins.py
@@ -7,7 +7,7 @@ import unidecode
 import lxml.html as html
 import pandas as pd
 import random
-from util.util import match_value, scraping_table_as_dataframe, contato_format_msg
+from util.util import match_value, scraping_table_as_dataframe, contato_format_msg, filter_sectors_before_names
 
 ## https://developer.amazon.com/en-US/docs/alexa/alexa-design/adaptable.html
 
@@ -22,6 +22,13 @@ def get_telefone(contato):
     
     contatos = scraping_table_as_dataframe(url)
     #TODO #10 Buscar fone por cruzamento de nome e setor #Leonardo.
+    checar_setor = filter_sectors_before_names(contato, contatos)
+    # se algum setor for identificado, os contatos são limitados a somente o setor que foi identificado
+    # e o contato é limitado somente à primeira palavra
+    if checar_setor.size > 0:
+        contatos = checar_setor
+        contato = contato.split(' ', 1)[0]
+
     eleito = match_value(contatos, contato)
 
     msg = contato_format_msg(eleito)

--- a/util/util.py
+++ b/util/util.py
@@ -124,3 +124,23 @@ def contato_format_msg(contato):
     else:
         text = "Infelizmente não tenho o telefone solicitado."
     return text
+
+def filter_sectors_before_names(contato, contatos):
+  new_contatos = pd.DataFrame(columns=['Setor', 'Contato', 'Prefixo', 'Ramal'])
+  
+  # se tiver a palavra 'coordenação' ele substitui por 'coord.'
+  if 'coordenação' in contato:
+    contato = contato.split('coordenação')[0] + 'coord.' + contato.split('coordenação')[1]
+  
+  composto = contato.split(' ', 1)[1] #capturando o composto
+  if ' ' in composto: # se o composto tiver mais de uma palavra
+    if len(composto.split(' ', 1)[0]) < 4: # se a primeira palavra de composto for menor que 4
+      composto = composto.split(' ', 1)[1]
+
+  setores = process.extract(composto, contatos.Setor.to_list())
+  
+  for setor in setores:
+    if setor[1] > 89:
+      new_contatos = new_contatos.append(contatos[contatos['Setor'] == setor[0]], ignore_index=True)
+  
+  return new_contatos


### PR DESCRIPTION
A ideia que pensei pra solucionar o problema foi filtrar os possíveis setores antes de passar o *contato* e *contatos* para o método **match_value** desta forma, se o usuário passar uma entrada tipo "Augusto da reitoria", meu método vai separar a segunda parte da frase, "*reitoria*" , e vai buscar qual setor corresponde a esta palavra, com um mínimo de taxa de acerto de 90%. Quando um ou mais setores forem identificados por este método, ele filtra o data frame de *contatos* para que apenas esses setores estejam presentes. Assim, quando o método **match_value** for aplicado usando esta lista de *contatos*, o resultado será com base no setor que foi identificado. 